### PR TITLE
Remove wildcard in `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mlflow>=2.0.0rc0
-scikit-learn>=1.1.*
-ipykernel>=6.12.*
-ipython>=7.32.*
+scikit-learn>=1.1
+ipykernel>=6.12
+ipython>=7.32


### PR DESCRIPTION
`*` is only valid for `!=` or `==`.

Reference https://discuss.python.org/t/how-to-pin-a-package-to-a-specific-major-version-or-lower/17077/8